### PR TITLE
chunk by 1 for 7z archives, chunk by 16 for others

### DIFF
--- a/crates/hoolamike/src/install_modlist/directives/preheat_archive_hash_paths.rs
+++ b/crates/hoolamike/src/install_modlist/directives/preheat_archive_hash_paths.rs
@@ -100,8 +100,8 @@ impl PreheatedArchiveHashPaths {
                                     .flat_map(|(a, b, c)| {
                                         c.tap_mut(|files| files.shuffle(&mut rand::thread_rng()))
                                             .into_iter()
-                                            // TODO: this is guesstimated, ideally they would be chunked by actual size
-                                            .chunks(64)
+                                            // Sequential for 7z archives since they are already multi-threaded and very slow, reduce chunk size for everything else to 16
+                                            .chunks(if b.last().extension().map(|ext| ext.to_string_lossy().to_lowercase()).as_deref() == Some("7z") { 1 } else { 16 })
                                             .into_iter()
                                             .map(move |c| (a.clone(), b.clone(), c.collect_vec()))
                                             .collect_vec()


### PR DESCRIPTION
- in my testing, took cpu utilization during 7z extraction from essentially idle to 100% 😊
- side effect is much more frequent progress updates during the archive extraction phase
- also set chunk size to 16 for all other archive types (this might be doing nothing but it hasn't hurt at all that i can tell)